### PR TITLE
Fix for creating missing child devices

### DIFF
--- a/devicetypes/smartthings/ikea-up-down-button.src/ikea-up-down-button.groovy
+++ b/devicetypes/smartthings/ikea-up-down-button.src/ikea-up-down-button.groovy
@@ -113,7 +113,7 @@ private void createChildButtonDevices(numberOfButtons) {
 		log.debug "Creating child $i"
         
         def children = childDevices
-        def childDevice = children.find{"${device.deviceNetworkId}:${i}"}
+        def childDevice = children.size >= i
         
         if (!childDevice)
         {


### PR DESCRIPTION
The old check always evaluates to true if at least one button exists.